### PR TITLE
Add configurable vehicle confirmation timing in GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,3 +83,6 @@ number and how many vehicles are detected.
 * The GUI counts unique vehicles using a simple tracker so the "Total cars"
   metric reflects how many different cars appeared rather than detections per
   frame.
+* You can adjust how long a detection must persist to be counted and how long a
+  car may be missing before starting a new track via the **Confirm time** and
+  **Lost time** fields in the GUI.


### PR DESCRIPTION
## Summary
- add VehicleTracker parameters for confirmation and lost times
- let the GUI customize confirm and lost times
- document the new GUI fields in README

## Testing
- `python3 -m py_compile code/main.py code/gui.py`
- `python3 code/main.py -h | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_684022299bac8327b081e01a24bfd53b